### PR TITLE
Custom env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ type Config struct {
 
 type Database struct {
 	Host     string `default:"localhost" validate:"required"`
-	Password string `validate:"required"`
+	Password string `validate:"required" envvar:"DB_PASS"`
 	DbName   string `default:"mydb"`
 	Username string `default:"root"`
 	Port     int    `default:"5432"`
@@ -46,7 +46,7 @@ func main() {
 }
 
 ```
-When you want to change, for example, DB Host of your applications you can do any of the following:
+When you want to change, a DB Host of your applications you can do it in 3 ways:
 1. create config `myconf.yaml` file in home directory 
 ``` 
 db:
@@ -100,6 +100,12 @@ Config file type could be any type supported by  [viper](https://github.com/spf1
 To set a flag via environment variable, make all letters uppercase and replace '.' with '_' in path. For example: app.Server.Port -> APP_SERVER_PORT
 
 You can set a prefix for environment variables. For example `NewConfReader("myconf").WithPrefix("MYAPP")` will search for environment variables like `MYAPP_DB_HOST`
+
+Environment variable names could be set in the struct tag `envvar`. For example 
+```
+Password string `envvar:"DB_PASS"`
+``` 
+will use value from environment variable `DB_PASS` to configure `Password` field.
 
 ### Command Line Arguments :computer: 
 

--- a/config_test.go
+++ b/config_test.go
@@ -28,6 +28,7 @@ type LocalConfig struct {
 	FromConfig         string
 	OverriddenByEvnVar string
 	OverriddenByArg    string
+	EnvVarName         string `envvar:"CUSTOM_ENV_VAR"`
 }
 
 func Test_ConfigReader(t *testing.T) {
@@ -48,6 +49,9 @@ func Test_ConfigReader(t *testing.T) {
 	os.Setenv("APP_OVERRIDDENBYEVNVAR", overriddenVar)
 	defer os.Unsetenv("APP_OVERRIDDENBYEVNVAR")
 
+	os.Setenv("CUSTOM_ENV_VAR", "valFromEnvVar")
+	defer os.Unsetenv("CUSTOM_ENV_VAR")
+
 	// act
 	err := confReader.Read(nc)
 
@@ -58,6 +62,7 @@ func Test_ConfigReader(t *testing.T) {
 		assert.Equal(t, "valFromConf", nc.App.FromConfig)
 		assert.Equal(t, valFromVar, nc.App.FromEnvVar)
 		assert.Equal(t, fromArgVal, nc.App.OverriddenByArg)
+		assert.Equal(t, "valFromEnvVar", nc.App.EnvVarName)
 	}
 }
 
@@ -129,7 +134,7 @@ type dmSibling struct {
 	FromEnvVar string
 }
 
-func Test_DumpStruct(t *testing.T) {
+func Test_dumpStruct(t *testing.T) {
 	m := map[string]*flagInfo{}
 	c := &ConfReader{}
 	c.dumpStruct(reflect.TypeOf(dmParent{}), "", m)


### PR DESCRIPTION
Fixes #1
This PR introduces the configuration of custom env var names for struct fields.
Here is an example:

```
EnvVarName         string `envvar:"CUSTOM_ENV_VAR"`
```
