### PR TITLE
Watch method to track config file changes

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -121,6 +121,48 @@ func Test_ReadFromJsonFile(t *testing.T) {
 	}
 }
 
+func Test_WatchWithFile(t *testing.T) {
+	resetFlags()
+	nc := &FullConfig{}
+
+	os.Mkdir("testdata/tmp", 0755)
+	err := os.WriteFile("testdata/tmp/changing_file.json", []byte(`{"verbose":"true"}`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("testdata/tmp")
+	confReader := NewConfReader("changing_file")
+	confReader.configDirs = []string{"testdata/tmp"}
+	err = confReader.Read(nc)
+	if assert.NoError(t, err) {
+		assert.Equal(t, true, nc.Verbose)
+	}
+	mutex := confReader.Watch()
+
+	t.Run("configChanges", func(t *testing.T) {
+		err = os.WriteFile("testdata/tmp/changing_file.json", []byte(`{"verbose":"false"}`), 0644)
+		if assert.NoError(t, err) {
+			time.Sleep(10 * time.Millisecond)
+			assert.Equal(t, false, nc.Verbose)
+		}
+	})
+
+	t.Run("configStructLock", func(t *testing.T) {
+		mutex.RLock()
+		err = os.WriteFile("testdata/tmp/changing_file.json", []byte(`{"verbose":"true"}`), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		//time.Sleep(time.Second)
+		assert.Equal(t, false, nc.Verbose)
+
+		mutex.RUnlock()
+		time.Sleep(10 * time.Millisecond)
+		assert.Equal(t, true, nc.Verbose)
+	})
+}
+
 type dmParent struct {
 	GlobalConfig `mapstructure:",squash"`
 	Conf         dmSibling `flag:"notAllowed"`

--- a/config_test.go
+++ b/config_test.go
@@ -125,8 +125,11 @@ func Test_WatchWithFile(t *testing.T) {
 	resetFlags()
 	nc := &FullConfig{}
 
-	os.Mkdir("testdata/tmp", 0755)
-	err := os.WriteFile("testdata/tmp/changing_file.json", []byte(`{"verbose":"true"}`), 0644)
+	err := os.Mkdir("testdata/tmp", 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile("testdata/tmp/changing_file.json", []byte(`{"verbose":"true"}`), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/num30/config
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-playground/validator/v10 v10.10.1


### PR DESCRIPTION
Add Watch method reloads the config struct every time config file has changed.
This functionality does not work for environment variables as they are kind of designed to stay unchanged for a running process.